### PR TITLE
Expose internals

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2015-2016, David Johnson
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of servant-swagger nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/servant-swagger.cabal
+++ b/servant-swagger.cabal
@@ -1,7 +1,9 @@
 name:                servant-swagger
 version:             0.0.0.1
-synopsis:            Swagger
-description:         Swagger
+synopsis:            Generate Swagger specification for your servant API.
+description:         Please see README.md
+homepage:            https://github.com/dmjio/servant-swagger
+bug-reports:         https://github.com/dmjio/servant-swagger/issues
 license:             BSD3
 license-file:        LICENSE
 author:              David Johnson
@@ -10,16 +12,19 @@ copyright:           David Johnson (c) 2015-2016
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10
-description:         This is an experimental release, this API is subject to change at any moment.
+extra-source-files:
+    README.md
+  , example/Main.hs
 
 source-repository head
   type:     git
-  location: git://github.com/dmjio/servant-swagger.git
+  location: https://github.com/dmjio/servant-swagger.git
 
 library
   ghc-options:         -Wall
-  exposed-modules:     Servant.Swagger
-  other-modules:       Servant.Swagger.Internal
+  exposed-modules:
+    Servant.Swagger
+    Servant.Swagger.Internal
   default-extensions:
              FlexibleContexts
            , DeriveGeneric


### PR DESCRIPTION
Expose `.Internal` modules. It is usually unwanted for a library to hide its internals.

I have also added some info to `.cabal` file.