### PR TITLE
Add Hackage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
     <a href="https://github.com/dmjio/servant-swagger">
         servant-swagger
     </a>
+    <br/>
+    <a href="http://hackage.haskell.org/package/servant-swagger">
+      <img alt="Hackage" src="https://img.shields.io/hackage/v/servant-swagger.svg" />
+    </a>
 </h1>
 
 <p align="center">


### PR DESCRIPTION
So that there is a direct link to Hackage with latest version displayed.

As a repo owner you can also click _Edit_ button to the right of the repo description and fill the **Website** field.